### PR TITLE
Remove extra text codecheck yml reference

### DIFF
--- a/codecheck.yml
+++ b/codecheck.yml
@@ -11,9 +11,7 @@ paper:
       ORCID: 0000-0002-8064-2251
     - name: Ajay Seth
       ORCID: 0000-0003-4217-1580
-  reference: >
-    BioRxiv preprint (2023) 
-    https://www.biorxiv.org/content/10.1101/2023.07.11.548542v1
+  reference: https://www.biorxiv.org/content/10.1101/2023.07.11.548542v1
 
 manifest:
   - file: codecheck/figure3-screenshot.png

--- a/codecheck.yml
+++ b/codecheck.yml
@@ -11,7 +11,7 @@ paper:
       ORCID: 0000-0002-8064-2251
     - name: Ajay Seth
       ORCID: 0000-0003-4217-1580
-  reference: https://www.biorxiv.org/content/10.1101/2023.07.11.548542v1
+  reference: https://doi.org/10.1101/2023.07.11.548542
 
 manifest:
   - file: codecheck/figure3-screenshot.png


### PR DESCRIPTION
In the `codecheck.yml` there was extra text in paper reference. I removed this extra text. 
Refer to comments in another PR about this: [link](https://github.com/codecheckers/register/issues/88#issuecomment-2343273428)

@nuest could you review and merge if you're okay with the changes. I do not have permission to merge.